### PR TITLE
Update comet.de_DE.po

### DIFF
--- a/comet.de_DE.po
+++ b/comet.de_DE.po
@@ -70,7 +70,7 @@ msgid "%d byte(s)"
 msgstr "%d Byte(s)"
 
 msgid "%d byte(s) per second"
-msgstr ""
+msgstr "%d Byte(s) pro Sekunde"
 
 #. A button to download the backup app for a single CPU type. "Only x86_64" or "Only x86_32
 msgid "%s only"
@@ -230,7 +230,7 @@ msgid "Activity"
 msgstr "Aktivität"
 
 msgid "Add"
-msgstr ""
+msgstr "Hinzufügen"
 
 # Definition of "Protected Item": This terminology is specific to Comet Backup. It is a set of files the user has chosen to be backed up.
 msgid "Add a new Protected Item"
@@ -346,7 +346,7 @@ msgid "Advanced options"
 msgstr "Erweiterte Optionen"
 
 msgid "Advanced settings"
-msgstr ""
+msgstr "Erweiterte Einstellungen"
 
 msgid "After"
 msgstr "Danach"
@@ -379,7 +379,7 @@ msgstr ""
 "Um eine einzelne Datenbank auszuwählen, entfernen Sie zuerst den Eintrag \"Alle Datenbankelemente\"."
 
 msgid "All devices"
-msgstr ""
+msgstr "Alle Geräte"
 
 #, qt-format
 msgid "All disks (%1)"
@@ -410,7 +410,7 @@ msgstr "Alle Geschützten Elemente"
 # Definition of "VMs": Abbreviation of 'Virtual Machines'. This is a well-known industry term. There might be a well-known translation, or, it might be common to use the English term. https://en.wikipedia.org/wiki/Virtual_machine
 # Definition of "VM": Abbreviation of 'Virtual Machine'. This is a well-known industry term. There might be a well-known translation, or, it might be common to use the English term. https://en.wikipedia.org/wiki/Virtual_machine
 msgid "All VMs"
-msgstr ""
+msgstr "Alle VMs"
 
 msgid "All writer components"
 msgstr "Alle Writer-Komponenten"
@@ -476,7 +476,7 @@ msgid "An imminent failure indicates either bad privileges or WOW64."
 msgstr ""
 
 msgid "An internal error has occurred"
-msgstr ""
+msgstr "Ein interner Fehler ist aufgetreten"
 
 msgid "An unknown exception occurred."
 msgstr ""
@@ -504,7 +504,7 @@ msgid "Any"
 msgstr ""
 
 msgid "Any CPU"
-msgstr ""
+msgstr "Beliebige CPU"
 
 # Definition of "Storage Vault": This terminology is specific to Comet Backup. It is a place where data can be stored.
 msgid "Any custom Retention policies will override the default policy for the Storage Vault."
@@ -545,7 +545,7 @@ msgid "API Key"
 msgstr "API-Schlüssel"
 
 msgid "Application Key"
-msgstr ""
+msgstr "Anwendungs-Schlüssel"
 
 msgid "Application key"
 msgstr "Anwendungs-Schlüssel"
@@ -707,7 +707,7 @@ msgid "B"
 msgstr "B"
 
 msgid "Back"
-msgstr ""
+msgstr "Zurück"
 
 # Definition of "Backblaze": This is a commercial service for storing files. If an official translation is available, it should be used. https://www.backblaze.com/b2/cloud-storage.html
 msgid "Backblaze B2 Cloud Storage"
@@ -861,7 +861,7 @@ msgid "Calculating"
 msgstr ""
 
 msgid "Calculating size..."
-msgstr "Größe wird berechnet..."
+msgstr "Grösse wird berechnet..."
 
 msgid "Campaign"
 msgstr ""
@@ -899,7 +899,7 @@ msgstr "Dieser Rechner kann nicht identifiziert werden: %s"
 
 # Definition of "Storage Vault": This terminology is specific to Comet Backup. It is a place where data can be stored.
 msgid "Can't restore: An invalid Storage Vault was selected."
-msgstr "Kann nicht wiederhergestellt werden: Ein ungültiges Datentresor wurde ausgewählt."
+msgstr "Kann nicht wiederhergestellt werden: Ein ungültiger Datentresor wurde ausgewählt."
 
 #, c-format
 msgid "Can't restore: failed to retrieve profile (%s)"
@@ -935,10 +935,10 @@ msgid "Cannot take VSS snapshot of '%s' filesystem (expected NTFS)"
 msgstr ""
 
 msgid "Category"
-msgstr ""
+msgstr "Kategorie"
 
 msgid "Certificate"
-msgstr ""
+msgstr "Zertifikat"
 
 msgid "Change account settings"
 msgstr "Benutzerkonto-Einstellungen ändern"
@@ -988,7 +988,7 @@ msgid "Cleanup"
 msgstr "Bereinigung"
 
 msgid "Cleanup complete!"
-msgstr ""
+msgstr "Bereinigung komplett!"
 
 msgid "Clear"
 msgstr ""
@@ -1018,7 +1018,7 @@ msgid "Client users"
 msgstr ""
 
 msgid "Clipboard"
-msgstr ""
+msgstr "Zwischenablage"
 
 msgid "Clipboard cleared"
 msgstr "Zwischenablage geleert"
@@ -1062,10 +1062,10 @@ msgid "Communicating with Hyper-V..."
 msgstr ""
 
 msgid "Company name"
-msgstr ""
+msgstr "Firmenname"
 
 msgid "Complete"
-msgstr ""
+msgstr "Komplett"
 
 msgid "Completed analyzing vault content."
 msgstr ""
@@ -1074,7 +1074,7 @@ msgid "Component"
 msgstr "Komponente"
 
 msgid "Compression"
-msgstr ""
+msgstr "Kompression"
 
 msgid "Configure external authentication sources for administrator accounts:"
 msgstr ""
@@ -1104,7 +1104,7 @@ msgid "Configure..."
 msgstr ""
 
 msgid "Connected Device"
-msgstr ""
+msgstr "Verbundenes Gerät"
 
 msgid "Connected Device Actions"
 msgstr "Aktionen für verbundenes Gerät"
@@ -1116,7 +1116,7 @@ msgid "Connected devices"
 msgstr "Verbundene Geräte"
 
 msgid "Connected since"
-msgstr ""
+msgstr "Verbunden seit"
 
 # Definition of "Storage Vault": This terminology is specific to Comet Backup. It is a place where data can be stored.
 msgid "Connecting to Storage Vault..."
@@ -1126,10 +1126,10 @@ msgid "Connection"
 msgstr "Verbindung"
 
 msgid "Connection ID"
-msgstr ""
+msgstr "Verbindungs-ID"
 
 msgid "Connection settings"
-msgstr ""
+msgstr "Verbindungseinstellungen"
 
 msgid "Connections"
 msgstr "Verbindungen"
@@ -1153,10 +1153,10 @@ msgid "contains"
 msgstr "enthält"
 
 msgid "Content"
-msgstr ""
+msgstr "Inhalt"
 
 msgid "Copied to clipboard."
-msgstr ""
+msgstr "In die Zwischenablage kopiert"
 
 msgid "Copied."
 msgstr "Kopiert."
@@ -1345,7 +1345,7 @@ msgid "Couldn't start engine"
 msgstr "Modul konnte nicht gestartet werden"
 
 msgid "Couldn't start process"
-msgstr ""
+msgstr "Prozess konnte nicht gestartert werden"
 
 #, c-format
 msgid "Couldn't submit log to server (%s) while logging message \"%s\""
@@ -1385,13 +1385,13 @@ msgid "CSV"
 msgstr ""
 
 msgid "Current password"
-msgstr ""
+msgstr "Aktuelles Passwort"
 
 msgid "Current password is incorrect"
-msgstr ""
+msgstr "Aktuelles Passwort ist nicht korrekt"
 
 msgid "Current status"
-msgstr ""
+msgstr "Aktueller Status"
 
 msgid "custom"
 msgstr "benutzerdefiniert"
@@ -1447,10 +1447,10 @@ msgid "Dashboard"
 msgstr "Instrumententafel"
 
 msgid "database"
-msgstr ""
+msgstr "Datenbank"
 
 msgid "Database"
-msgstr ""
+msgstr "Datenbank"
 
 #, qt-format
 msgid "Database '%1'"
@@ -1469,16 +1469,16 @@ msgid "Day of week"
 msgstr "Wochentag"
 
 msgid "day(s)"
-msgstr ""
+msgstr "Tage(e)"
 
 msgid "days"
-msgstr ""
+msgstr "Tage"
 
 msgid "Days"
 msgstr "Tage"
 
 msgid "December"
-msgstr ""
+msgstr "Dezember"
 
 msgid "Decreasing"
 msgstr ""
@@ -1785,25 +1785,25 @@ msgid "Email"
 msgstr ""
 
 msgid "Email Address"
-msgstr "E-Mail-Addresse"
+msgstr "E-Mail-Adresse"
 
 msgid "Email address"
-msgstr ""
+msgstr "E-Mail-Adresse"
 
 msgid "Email Addresses"
-msgstr ""
+msgstr "E-Mail-Adressen"
 
 msgid "Email backup reports to this account"
 msgstr "Berichte über Datensicherung an dieses Konto als E-Mail senden"
 
 msgid "Email Report"
-msgstr ""
+msgstr "E-Mail-Bericht"
 
 msgid "Email reports"
-msgstr ""
+msgstr "E-Mail-Berichte"
 
 msgid "Email Reports"
-msgstr ""
+msgstr "E-Mail-Berichte"
 
 msgid "Email service bulletins to this account"
 msgstr "Service-Berichte an dieses Konto als E-Mail senden"
@@ -1957,14 +1957,14 @@ msgid "Exchange Organization"
 msgstr "Exchange-Organisation"
 
 msgid "Exclude"
-msgstr "Ausschließen"
+msgstr "Ausschliessen"
 
 msgid "Exclude file..."
 msgstr ""
 
 # Definition of "Regex": This is a well-known industry term. There might be a well-known translation, or, it might be common to use the English term. https://en.wikipedia.org/wiki/Regular_expression
 msgid "Exclude regex"
-msgstr "Regex ausschließen"
+msgstr "Regex ausschliessen"
 
 msgid "Exclude specified"
 msgstr ""
@@ -1981,13 +1981,13 @@ msgid "Export configuration"
 msgstr "Konfiguration exportieren"
 
 msgid "External"
-msgstr ""
+msgstr "Extern"
 
 msgid "External authentication sources"
 msgstr ""
 
 msgid "External Source"
-msgstr ""
+msgstr "Externe Quelle"
 
 msgid "Externally managed"
 msgstr ""
@@ -1996,7 +1996,7 @@ msgid "Extra data (optional)"
 msgstr "Zusätzliche Daten (optional)"
 
 msgid "Failed"
-msgstr ""
+msgstr "Fehlgeschlagen"
 
 # Definition of "Elevator": This terminology is specific to Comet Backup. This is an internal part of our application that can raise the permission level, when needed. The software 'elevates' its permission level using the 'elevator'.
 #, c-format
@@ -2089,7 +2089,7 @@ msgid "Feature unsupported on this server"
 msgstr ""
 
 msgid "February"
-msgstr ""
+msgstr "Februar"
 
 # Definition of "U2F": This is a standard for two-factor authentication. This is a well-known industry term. There might be a well-known translation, or, it might be common to use the English term. https://en.wikipedia.org/wiki/Universal_2nd_Factor
 # Definition of "FIDO": This is the name of a consortium that work to develop user-login systems. If an official translation is available, it should be used. https://en.wikipedia.org/wiki/FIDO_Alliance
@@ -2097,7 +2097,7 @@ msgid "FIDO U2F"
 msgstr ""
 
 msgid "File"
-msgstr ""
+msgstr "Datei"
 
 msgid "Filename access"
 msgstr ""
@@ -2233,11 +2233,11 @@ msgstr "Google Cloud Storage"
 
 #. Used by the search system to create custom searches. "[FILE SIZE] greater than [SOMETHING]
 msgid "greater"
-msgstr "größer"
+msgstr "grösser"
 
 #. Used by the search system to create custom searches. "[USERNAME] greater or equal than [SOMETHING]
 msgid "greater or equal"
-msgstr "größer gleich"
+msgstr "grösser oder gleich"
 
 msgid "Hashed"
 msgstr ""
@@ -2381,7 +2381,7 @@ msgid "Import settings from another backup product"
 msgstr ""
 
 msgid "Imported"
-msgstr ""
+msgstr "Importiert"
 
 msgid "Importing advanced retention policies is not yet supported; keeping all backups forever"
 msgstr ""
@@ -2432,10 +2432,10 @@ msgid "Intermediate"
 msgstr ""
 
 msgid "Internal"
-msgstr ""
+msgstr "Intern"
 
 msgid "Internal error"
-msgstr ""
+msgstr "Interner Error"
 
 # Definition of "Storage Vault": This terminology is specific to Comet Backup. It is a place where data can be stored.
 #, c-format
@@ -2462,7 +2462,7 @@ msgid "Invalid device selected"
 msgstr ""
 
 msgid "Invalid email address"
-msgstr ""
+msgstr "Ungültige E-Mail-Adresse"
 
 msgid "Invalid encryption key specified"
 msgstr ""
@@ -2499,7 +2499,7 @@ msgid "Invalid Protected Item selected."
 msgstr "Ungültiges Geschütztes Element ausgewählt."
 
 msgid "Invalid request"
-msgstr ""
+msgstr "Ungültige Anfrage"
 
 msgid "Invalid response from the server."
 msgstr "Ungültige Antwort vom Server."
@@ -2536,7 +2536,7 @@ msgid "Invalid username: %s"
 msgstr "Ungültiger Benutzername: %s"
 
 msgid "IP Address"
-msgstr ""
+msgstr "IP-Adresse"
 
 msgid "IP address not whitelisted"
 msgstr ""
@@ -2561,7 +2561,7 @@ msgid "Items"
 msgstr "Elemente"
 
 msgid "January"
-msgstr ""
+msgstr "Januar"
 
 msgid "Job"
 msgstr ""
@@ -2585,10 +2585,10 @@ msgid "Job Search"
 msgstr "Auftragssuche"
 
 msgid "July"
-msgstr ""
+msgstr "July"
 
 msgid "June"
-msgstr ""
+msgstr "June"
 
 msgid "KB"
 msgstr "KB"
@@ -2620,7 +2620,7 @@ msgid "Key ID"
 msgstr ""
 
 msgid "Known servers"
-msgstr ""
+msgstr "Bekannte Server"
 
 msgid "Language"
 msgstr "Sprache"
@@ -2635,7 +2635,7 @@ msgid "Last backup job"
 msgstr ""
 
 msgid "Last scan"
-msgstr ""
+msgstr "Letzter Scan"
 
 msgid "Last wake event"
 msgstr ""
@@ -2679,7 +2679,7 @@ msgstr "kleiner"
 
 #. Used by the search system to create custom searches. "[FILE SIZE] less or equal than [SOMETHING]
 msgid "less or equal"
-msgstr "kleiner gleich"
+msgstr "kleiner oder gleich"
 
 msgid "Limit backup to use only 1 disk thread"
 msgstr ""
@@ -2711,10 +2711,10 @@ msgid "Loading Storage Vault metadata for deep verification (%d/%d)..."
 msgstr ""
 
 msgid "Local"
-msgstr ""
+msgstr "Lokal"
 
 msgid "Local address"
-msgstr ""
+msgstr "Lokale Adresse"
 
 msgid "Local Path"
 msgstr "Lokaler Pfad"
@@ -2781,7 +2781,7 @@ msgid "Login"
 msgstr "Anmeldung"
 
 msgid "Login as user"
-msgstr ""
+msgstr "Als Benutzer anmelden"
 
 #, c-format
 msgid "Login to '%s' failed: %s"
@@ -2830,7 +2830,7 @@ msgid "Mandatory file and folder exclusions"
 msgstr ""
 
 msgid "March"
-msgstr ""
+msgstr "März"
 
 msgid "Master Application Key"
 msgstr ""
@@ -2839,7 +2839,7 @@ msgid "Master Key ID"
 msgstr ""
 
 msgid "May"
-msgstr ""
+msgstr "Mai"
 
 msgid "MB"
 msgstr "MB"
@@ -2851,10 +2851,10 @@ msgid "Measure"
 msgstr "Bestimmen"
 
 msgid "Member"
-msgstr ""
+msgstr "Mitglied"
 
 msgid "Members"
-msgstr ""
+msgstr "Mitglieder"
 
 msgid "Message"
 msgstr "Meldung"
@@ -2883,13 +2883,13 @@ msgid "Microsoft SQL Server databases"
 msgstr ""
 
 msgid "minute(s)"
-msgstr ""
+msgstr "Minute(n)"
 
 msgid "Minutes"
-msgstr ""
+msgstr "Minuten"
 
 msgid "minutes"
-msgstr ""
+msgstr "Minuten"
 
 msgid "Minutes past hour"
 msgstr "Minuten nach der vollen Stunde"
@@ -2901,7 +2901,7 @@ msgid "Misconfiguration can cause data loss."
 msgstr ""
 
 msgid "Misconfiguration: Unexpected 'exclude' directive when 'all databases' was not selected"
-msgstr "Fehlkonfiguration: Unerwartete \"ausschließen\"-Anweisung, wenn \"alle Datenbanken\" nicht ausgewählt wurde"
+msgstr "Fehlkonfiguration: Unerwartete \"ausschliessen\"-Anweisung, wenn \"alle Datenbanken\" nicht ausgewählt wurde"
 
 # Definition of "VMs": Abbreviation of 'Virtual Machines'. This is a well-known industry term. There might be a well-known translation, or, it might be common to use the English term. https://en.wikipedia.org/wiki/Virtual_machine
 # Definition of "VM": Abbreviation of 'Virtual Machine'. This is a well-known industry term. There might be a well-known translation, or, it might be common to use the English term. https://en.wikipedia.org/wiki/Virtual_machine
@@ -2980,7 +2980,7 @@ msgid "ms"
 msgstr ""
 
 msgid "Multiple"
-msgstr ""
+msgstr "Mehrfach"
 
 msgid "Multiple commands"
 msgstr ""
@@ -3269,7 +3269,7 @@ msgid "Notice for '%s': size changed during backup (expected %d bytes, got %d)"
 msgstr ""
 
 msgid "November"
-msgstr ""
+msgstr "November"
 
 #, c-format
 msgid "Now running updated software (%s)."
@@ -3282,7 +3282,7 @@ msgid "Number must be a multiple of %d"
 msgstr "Muss ein Vielfaches von %d sein"
 
 msgid "Number must be greater than %d"
-msgstr "Muss größer als %d sein"
+msgstr "Muss grösser als %d sein"
 
 msgid "Number must be lower than %d"
 msgstr "Muss kleiner als %d sein"
@@ -3294,7 +3294,7 @@ msgid "Number of lines"
 msgstr ""
 
 msgid "October"
-msgstr ""
+msgstr "Oktober"
 
 msgid "Off"
 msgstr ""
@@ -3354,7 +3354,7 @@ msgid "OpenStack Swift"
 msgstr "OpenStack Swift"
 
 msgid "Operating system"
-msgstr ""
+msgstr "Betriebssystem"
 
 msgid "Operation"
 msgstr "Operation"
@@ -3625,7 +3625,7 @@ msgid "Previous"
 msgstr "Zurück"
 
 msgid "Primary"
-msgstr ""
+msgstr "Primär"
 
 msgid "Primary Preferred"
 msgstr ""
@@ -4333,7 +4333,7 @@ msgid "Session Options"
 msgstr ""
 
 msgid "Set to zero to use the default connection limit."
-msgstr "Auf Null setzen, um das standardmäßige Verbindungslimit zu verwenden."
+msgstr "Auf Null setzen, um das standardmässige Verbindungslimit zu verwenden."
 
 msgid "Settings"
 msgstr ""
@@ -4385,16 +4385,16 @@ msgid "Single"
 msgstr ""
 
 msgid "Size"
-msgstr "Größe"
+msgstr "Grösse"
 
 msgid "Size measured on:"
-msgstr "Größe bestimmt auf:"
+msgstr "Grösse bestimmt auf:"
 
 msgid "Size measurement took %s"
-msgstr "Bestimmung der Größe dauerte %s"
+msgstr "Bestimmung der Grösse dauerte %s"
 
 msgid "Size not measured"
-msgstr "Größe nicht bestimmt"
+msgstr "Grösse nicht bestimmt"
 
 msgid "Skip if already running"
 msgstr ""
@@ -4421,11 +4421,11 @@ msgstr ""
 
 # Definition of "SMTP": This is a well-known industry term. There might be a well-known translation, or, it might be common to use the English term. https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol
 msgid "SMTP Server"
-msgstr ""
+msgstr "SMTP-Server"
 
 # Definition of "SMTP": This is a well-known industry term. There might be a well-known translation, or, it might be common to use the English term. https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol
 msgid "SMTP server"
-msgstr ""
+msgstr "SMTP-Server"
 
 msgid "Snapshot"
 msgstr ""
@@ -4455,7 +4455,7 @@ msgid "sort column descending"
 msgstr "Spalte absteigend sortieren"
 
 msgid "Source"
-msgstr ""
+msgstr "Quelle"
 
 msgid "Source identifier (optional)"
 msgstr "Quellenbezeichnung (optional)"
@@ -4903,7 +4903,7 @@ msgstr ""
 
 # Definition of "Protected Item": This terminology is specific to Comet Backup. It is a set of files the user has chosen to be backed up.
 msgid "There's no free quota to run this job. Reduce the size of other Protected Items before retrying."
-msgstr "Es gibt keine freie Quote, um diesen Auftrag auszuführen. Bevor Sie wiederholen, verringern Sie die Größe der anderen Geschützten Elemente."
+msgstr "Es gibt keine freie Quote, um diesen Auftrag auszuführen. Bevor Sie wiederholen, verringern Sie die Grösse der anderen Geschützten Elemente."
 
 # Definition of "Protected Item": This terminology is specific to Comet Backup. It is a set of files the user has chosen to be backed up.
 msgid "This action will also remove all Protected Items for this device."
@@ -5043,7 +5043,7 @@ msgid "Total scans"
 msgstr ""
 
 msgid "Total Size"
-msgstr "Gesamtgröße"
+msgstr "Gesamtgrösse"
 
 # Definition of "TOTP": This is a well-known industry term. There might be a well-known translation, or, it might be common to use the English term. https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm
 msgid "TOTP"


### PR DESCRIPTION
- German/Austria specific "ß" replaced with international German ""ss".
- Typos fixed
- Continued with translation